### PR TITLE
fix(audio-recognition): EndOfDictation messages replaces last detected recognition.

### DIFF
--- a/lib/ex_azure_speech/speech_to_text/socket_config.ex
+++ b/lib/ex_azure_speech/speech_to_text/socket_config.ex
@@ -42,7 +42,7 @@ defmodule ExAzureSpeech.SpeechToText.SocketConfig do
             ],
             recognition_mode: [
               type: {:in, [:interactive, :conversation, :dictation]},
-              default: :interactive,
+              default: :conversation,
               doc: """
               The recognition mode to be used. `:interactive` is optimized for short phrases, `:conversation` is optimized for conversational speech, and `:dictation` is optimized for long-form speech.
               """

--- a/lib/ex_azure_speech/speech_to_text/websocket.ex
+++ b/lib/ex_azure_speech/speech_to_text/websocket.ex
@@ -393,7 +393,7 @@ defmodule ExAzureSpeech.SpeechToText.Websocket do
         {:ok,
          %ConnectionState{
            state
-           | responses: [{:recognition, payload}],
+           | responses: state.responses ++ [{:recognition, payload}],
              current_stage: :speech_phrase
          }}
 

--- a/test/ex_azure_speech/speech_to_text/integration/basic_recognition_test.exs
+++ b/test/ex_azure_speech/speech_to_text/integration/basic_recognition_test.exs
@@ -397,8 +397,8 @@ defmodule ExAzureSpeech.SpeechToText.Integration.BasicRecognitionTest do
         recognition_status: "Success",
         display_text:
           "Voor MeToo, veroordeelde Belgische TV maker verbreekt stilzwijgen, Ik ben fout geweest.",
-        duration: 54_800_000,
-        offset: 2_100_000,
+        duration: _,
+        offset: _,
         primary_language: nil,
         n_best: nil,
         speaker_id: nil
@@ -410,8 +410,8 @@ defmodule ExAzureSpeech.SpeechToText.Integration.BasicRecognitionTest do
         recognition_status: "Success",
         display_text:
           "De voor grensoverschrijdend gedrag veroordeelde Belgische TV maker Bart de pauw heeft voor het eerst in 7 jaar van zich Laten horen.",
-        duration: 78_700_000,
-        offset: 4_000_000,
+        duration: _,
+        offset: _,
         primary_language: nil,
         n_best: nil,
         speaker_id: nil


### PR DESCRIPTION
Every last recognition in conversation/dictation mode was dropped because of the EndOfDictation message, which was overriding the response.